### PR TITLE
feat: save recall results as Obsidian notes

### DIFF
--- a/main.js
+++ b/main.js
@@ -639,7 +639,8 @@ ${content}`;
       snippet: this.buildSnippet(item.content),
       content: item.content,
       tags: this.parseMemoryTags(item.tags),
-      score: typeof item.score === "number" && Number.isFinite(item.score) ? item.score : null
+      score: typeof item.score === "number" && Number.isFinite(item.score) ? item.score : null,
+      createdAt: item.created_at != null ? String(item.created_at) : null
     }));
     const insight = typeof data.insight === "string" && data.insight.trim() ? data.insight.trim() : null;
     return { ok: true, results, insight };
@@ -649,6 +650,180 @@ ${content}`;
     if (flat.length <= maxChars)
       return flat;
     return flat.slice(0, maxChars).trim() + "\u2026";
+  }
+  normalizeMarkdown(content) {
+    var _a;
+    const isStructural = (line) => {
+      const trimmed = line.trim();
+      return /^#{1,6}\s/.test(trimmed) || /^[-*+]\s/.test(trimmed) || /^\d+[.)]\s/.test(trimmed) || /^>/.test(trimmed) || /^```/.test(trimmed);
+    };
+    const rawLines = content.split("\n");
+    const output = [];
+    const outputInFence = [];
+    let inFence = false;
+    for (const rawLine of rawLines) {
+      const trimmedRight = rawLine.replace(/[ \t]+$/, "");
+      const trimmed = trimmedRight.trim();
+      const isFenceMarker = /^```/.test(trimmed);
+      if (isFenceMarker) {
+        if (!inFence) {
+          const prev2 = output.length > 0 ? output[output.length - 1] : null;
+          if (prev2 !== null && prev2.trim() !== "") {
+            output.push("");
+            outputInFence.push(false);
+          }
+        }
+        output.push(trimmedRight);
+        outputInFence.push(inFence);
+        inFence = !inFence;
+        continue;
+      }
+      if (inFence) {
+        output.push(rawLine);
+        outputInFence.push(true);
+        continue;
+      }
+      let line = trimmedRight;
+      if (/^\s*[*+]\s/.test(line)) {
+        line = line.replace(/^(\s*)[*+](\s)/, "$1-$2");
+      }
+      const prev = output.length > 0 ? output[output.length - 1] : null;
+      const prevTrimmed = (_a = prev == null ? void 0 : prev.trim()) != null ? _a : "";
+      const prevIsStructural = prev !== null && isStructural(prev);
+      const lineIsStructural = isStructural(line);
+      if (trimmed !== "" && prev !== null && prevTrimmed !== "" && lineIsStructural !== prevIsStructural) {
+        output.push("");
+        outputInFence.push(false);
+      }
+      output.push(line);
+      outputInFence.push(false);
+    }
+    const collapsed = [];
+    let i = 0;
+    while (i < output.length) {
+      if (output[i].trim() === "") {
+        let j = i;
+        while (j < output.length && output[j].trim() === "")
+          j++;
+        const runLength = j - i;
+        const hasAnyInFence = outputInFence.slice(i, j).some((isFenced) => isFenced);
+        if (runLength >= 3 && !hasAnyInFence) {
+          collapsed.push("");
+        } else {
+          for (let k = i; k < j; k++)
+            collapsed.push(output[k]);
+        }
+        i = j;
+      } else {
+        collapsed.push(output[i]);
+        i++;
+      }
+    }
+    return collapsed.join("\n").trim();
+  }
+  buildFrontmatter(lines) {
+    return `---
+${lines.join("\n")}
+---`;
+  }
+  async createAndOpenNote(folder, title, body) {
+    var _a;
+    const targetFolder = folder.trim() || ((_a = this.settings.importFolder) == null ? void 0 : _a.trim()) || "_Second Brain/Inbox";
+    await this.ensureFolderExists(targetFolder);
+    const sanitizedTitle = this.sanitizeFileName(title);
+    const path = this.getAvailableFilePath(targetFolder, sanitizedTitle);
+    await this.app.vault.create(path, body);
+    const file = this.app.vault.getAbstractFileByPath(path);
+    if (file instanceof import_obsidian.TFile) {
+      await this.app.workspace.getLeaf(true).openFile(file);
+    }
+    new import_obsidian.Notice(`Saved note: ${sanitizedTitle}`);
+  }
+  defaultSearchNoteTitle(query) {
+    const trimmed = query.trim();
+    if (!trimmed)
+      return `Search - ${(/* @__PURE__ */ new Date()).toISOString().slice(0, 10)}`;
+    return this.sanitizeFileName(trimmed);
+  }
+  defaultInsightNoteTitle(query) {
+    const trimmed = query.trim();
+    if (!trimmed)
+      return `Insight - ${(/* @__PURE__ */ new Date()).toISOString().slice(0, 10)}`;
+    return this.sanitizeFileName(`Insight - ${trimmed}`);
+  }
+  formatResultDateLabel(createdAt) {
+    if (!createdAt)
+      return null;
+    const match = createdAt.match(/^\d{4}-\d{2}-\d{2}/);
+    return match ? match[0] : createdAt;
+  }
+  async saveSearchResultsAsNote(query, results, title, folder) {
+    const recalledAt = (/* @__PURE__ */ new Date()).toISOString();
+    const escapedQuery = query.replace(/"/g, '\\"');
+    const frontmatter = this.buildFrontmatter([
+      `query: "${escapedQuery}"`,
+      `recalled_at: "${recalledAt}"`,
+      `source: second-brain`
+    ]);
+    const entries = results.map((result) => {
+      const meta = [];
+      if (result.score !== null)
+        meta.push(`score: ${result.score.toFixed(1)}`);
+      const dateLabel = this.formatResultDateLabel(result.createdAt);
+      if (dateLabel)
+        meta.push(dateLabel);
+      const metaText = meta.length > 0 ? ` (${meta.join(" \xB7 ")})` : "";
+      const normalizedContent = this.normalizeMarkdown(result.content);
+      const indentedContent = normalizedContent.split("\n").map((line) => line.trim() === "" ? "" : `  ${line}`).join("\n");
+      const tagsLine = result.tags.length > 0 ? `
+  Tags: ${result.tags.map((t) => `#${t}`).join(" ")}` : "";
+      return `- **${result.title}**${metaText}
+${indentedContent}${tagsLine}`;
+    });
+    const body = `${frontmatter}
+
+# ${title}
+
+${entries.join("\n\n")}
+`;
+    await this.createAndOpenNote(folder, title, body);
+  }
+  async saveSingleResultAsNote(query, result, title, folder) {
+    const recalledAt = (/* @__PURE__ */ new Date()).toISOString();
+    const escapedQuery = query.replace(/"/g, '\\"');
+    const frontmatter = this.buildFrontmatter([
+      `query: "${escapedQuery}"`,
+      `recalled_at: "${recalledAt}"`,
+      `source: second-brain`
+    ]);
+    const normalizedContent = this.normalizeMarkdown(result.content);
+    const body = `${frontmatter}
+
+# ${title}
+
+Source memory ID: ${result.id}
+
+${normalizedContent}
+`;
+    await this.createAndOpenNote(folder, title, body);
+  }
+  async saveInsightAsNote(query, insight, title, folder) {
+    const recalledAt = (/* @__PURE__ */ new Date()).toISOString();
+    const escapedQuery = query.replace(/"/g, '\\"');
+    const frontmatter = this.buildFrontmatter([
+      `query: "${escapedQuery}"`,
+      `recalled_at: "${recalledAt}"`,
+      `source: second-brain`,
+      `type: insight`
+    ]);
+    const normalizedInsight = this.normalizeMarkdown(insight);
+    const body = `${frontmatter}
+
+# ${title}
+
+${normalizedInsight}
+`;
+    await this.createAndOpenNote(folder, title, body);
   }
   async loadSettings() {
     this.settings = Object.assign({}, DEFAULT_SETTINGS, await this.loadData());
@@ -663,6 +838,7 @@ var SearchView = class extends import_obsidian.ItemView {
     this.expandedIds = /* @__PURE__ */ new Set();
     this.isSearching = false;
     this.requestToken = 0;
+    this.lastQuery = "";
     this.plugin = plugin;
   }
   getViewType() {
@@ -707,6 +883,7 @@ var SearchView = class extends import_obsidian.ItemView {
     const query = this.queryInput.value;
     const token = ++this.requestToken;
     this.isSearching = true;
+    this.lastQuery = query;
     this.renderLoading();
     try {
       const outcome = await this.plugin.recallMemories(query);
@@ -735,11 +912,29 @@ var SearchView = class extends import_obsidian.ItemView {
       cls: "second-brain-search-status second-brain-search-error"
     });
   }
+  defaultSaveFolder() {
+    var _a;
+    return ((_a = this.plugin.settings.importFolder) == null ? void 0 : _a.trim()) || "_Second Brain/Inbox";
+  }
   renderResults(results, insight) {
     this.resultsEl.empty();
     if (insight) {
       const insightEl = this.resultsEl.createDiv({ cls: "second-brain-search-insight" });
-      insightEl.setText(insight);
+      const insightText = insightEl.createDiv({ cls: "second-brain-search-insight-text" });
+      insightText.setText(insight);
+      const saveInsightButton = insightEl.createEl("button", {
+        cls: "second-brain-save-icon-button",
+        attr: { "aria-label": "Save insight as note" }
+      });
+      (0, import_obsidian.setIcon)(saveInsightButton, "file-plus");
+      saveInsightButton.addEventListener("click", () => {
+        new SaveNoteModal(
+          this.app,
+          this.plugin.defaultInsightNoteTitle(this.lastQuery),
+          this.defaultSaveFolder(),
+          (title, folder) => this.plugin.saveInsightAsNote(this.lastQuery, insight, title, folder)
+        ).open();
+      });
     }
     if (results.length === 0) {
       this.resultsEl.createEl("p", {
@@ -748,6 +943,16 @@ var SearchView = class extends import_obsidian.ItemView {
       });
       return;
     }
+    const saveAllRow = this.resultsEl.createDiv({ cls: "second-brain-search-save-all-row" });
+    const saveAllButton = saveAllRow.createEl("button", { text: "Save all as note" });
+    saveAllButton.addEventListener("click", () => {
+      new SaveNoteModal(
+        this.app,
+        this.plugin.defaultSearchNoteTitle(this.lastQuery),
+        this.defaultSaveFolder(),
+        (title, folder) => this.plugin.saveSearchResultsAsNote(this.lastQuery, results, title, folder)
+      ).open();
+    });
     const list = this.resultsEl.createEl("ul", { cls: "second-brain-search-list" });
     for (const result of results) {
       this.renderResultItem(list, result);
@@ -777,6 +982,20 @@ var SearchView = class extends import_obsidian.ItemView {
         cls: "second-brain-search-item-score"
       });
     }
+    const saveResultButton = titleRow.createEl("button", {
+      cls: "second-brain-save-icon-button",
+      attr: { "aria-label": "Save memory as note" }
+    });
+    (0, import_obsidian.setIcon)(saveResultButton, "file-plus");
+    saveResultButton.addEventListener("click", (evt) => {
+      evt.stopPropagation();
+      new SaveNoteModal(
+        this.app,
+        result.title,
+        this.defaultSaveFolder(),
+        (title, folder) => this.plugin.saveSingleResultAsNote(this.lastQuery, result, title, folder)
+      ).open();
+    });
     const bodyText = isExpanded ? result.content.replace(/\s+/g, " ").trim() : result.snippet;
     item.createEl("p", {
       text: bodyText,
@@ -788,6 +1007,51 @@ var SearchView = class extends import_obsidian.ItemView {
         tagsEl.createEl("span", { text: `#${tag}` });
       }
     }
+  }
+};
+var SaveNoteModal = class extends import_obsidian.Modal {
+  constructor(app, defaultTitle, defaultFolder, onSave) {
+    super(app);
+    this.titleValue = defaultTitle;
+    this.folderValue = defaultFolder;
+    this.onSave = onSave;
+  }
+  onOpen() {
+    const { contentEl } = this;
+    contentEl.createEl("h3", { text: "Save as note" });
+    new import_obsidian.Setting(contentEl).setName("Title").addText(
+      (text) => text.setValue(this.titleValue).onChange((value) => {
+        this.titleValue = value;
+      })
+    );
+    new import_obsidian.Setting(contentEl).setName("Folder").addText(
+      (text) => text.setValue(this.folderValue).onChange((value) => {
+        this.folderValue = value;
+      })
+    );
+    const buttonRow = contentEl.createDiv({ cls: "second-brain-save-note-buttons" });
+    const cancelButton = buttonRow.createEl("button", { text: "Cancel" });
+    cancelButton.addEventListener("click", () => this.close());
+    const saveButton = buttonRow.createEl("button", { text: "Save", cls: "mod-cta" });
+    saveButton.addEventListener("click", () => void this.handleSave(saveButton));
+  }
+  async handleSave(saveButton) {
+    if (!this.titleValue.trim()) {
+      new import_obsidian.Notice("Title cannot be empty.");
+      return;
+    }
+    saveButton.disabled = true;
+    try {
+      await this.onSave(this.titleValue, this.folderValue);
+      this.close();
+    } catch (e) {
+      const message = e instanceof Error ? e.message : "Failed to save note.";
+      new import_obsidian.Notice(message);
+      saveButton.disabled = false;
+    }
+  }
+  onClose() {
+    this.contentEl.empty();
   }
 };
 var SecondBrainSettingTab = class extends import_obsidian.PluginSettingTab {

--- a/main.ts
+++ b/main.ts
@@ -127,6 +127,7 @@ interface NormalizedRecallResult {
   content: string;
   tags: string[];
   score: number | null;
+  createdAt: string | null;
 }
 
 const VIEW_TYPE_SEARCH = "second-brain-search";
@@ -825,6 +826,7 @@ imported_at: "${importedAt}"${tagsYaml}
         content: item.content,
         tags: this.parseMemoryTags(item.tags),
         score: typeof item.score === "number" && Number.isFinite(item.score) ? item.score : null,
+        createdAt: item.created_at != null ? String(item.created_at) : null,
       }));
 
     const insight = typeof data.insight === "string" && data.insight.trim() ? data.insight.trim() : null;

--- a/main.ts
+++ b/main.ts
@@ -3,6 +3,7 @@ import {
   Editor,
   ItemView,
   MarkdownView,
+  Modal,
   Plugin,
   PluginSettingTab,
   Setting,
@@ -12,6 +13,7 @@ import {
   WorkspaceLeaf,
   requestUrl,
   normalizePath,
+  setIcon,
 } from "obsidian";
 
 // ─── Settings ─────────────────────────────────────────────────────────────────
@@ -1100,6 +1102,71 @@ class SearchView extends ItemView {
         tagsEl.createEl("span", { text: `#${tag}` });
       }
     }
+  }
+}
+
+// ─── Save Note Modal ──────────────────────────────────────────────────────────
+
+class SaveNoteModal extends Modal {
+  titleValue: string;
+  folderValue: string;
+  onSave: (title: string, folder: string) => Promise<void>;
+
+  constructor(
+    app: App,
+    defaultTitle: string,
+    defaultFolder: string,
+    onSave: (title: string, folder: string) => Promise<void>
+  ) {
+    super(app);
+    this.titleValue = defaultTitle;
+    this.folderValue = defaultFolder;
+    this.onSave = onSave;
+  }
+
+  onOpen() {
+    const { contentEl } = this;
+    contentEl.createEl("h3", { text: "Save as note" });
+
+    new Setting(contentEl)
+      .setName("Title")
+      .addText((text) =>
+        text.setValue(this.titleValue).onChange((value) => {
+          this.titleValue = value;
+        })
+      );
+
+    new Setting(contentEl)
+      .setName("Folder")
+      .addText((text) =>
+        text.setValue(this.folderValue).onChange((value) => {
+          this.folderValue = value;
+        })
+      );
+
+    const buttonRow = contentEl.createDiv({ cls: "second-brain-save-note-buttons" });
+
+    const cancelButton = buttonRow.createEl("button", { text: "Cancel" });
+    cancelButton.addEventListener("click", () => this.close());
+
+    const saveButton = buttonRow.createEl("button", { text: "Save", cls: "mod-cta" });
+    saveButton.addEventListener("click", () => void this.handleSave(saveButton));
+  }
+
+  async handleSave(saveButton: HTMLButtonElement) {
+    saveButton.disabled = true;
+    try {
+      await this.onSave(this.titleValue, this.folderValue);
+      this.close();
+    } catch (e) {
+      const message = e instanceof Error ? e.message : "Failed to save note.";
+      new Notice(message);
+      saveButton.disabled = false;
+    }
+  }
+
+  onClose() {
+    this.contentEl.empty();
   }
 }
 

--- a/main.ts
+++ b/main.ts
@@ -1321,6 +1321,10 @@ class SaveNoteModal extends Modal {
   }
 
   async handleSave(saveButton: HTMLButtonElement) {
+    if (!this.titleValue.trim()) {
+      new Notice("Title cannot be empty.");
+      return;
+    }
     saveButton.disabled = true;
     try {
       await this.onSave(this.titleValue, this.folderValue);

--- a/main.ts
+++ b/main.ts
@@ -927,6 +927,125 @@ imported_at: "${importedAt}"${tagsYaml}
     return collapsed.join("\n").trim();
   }
 
+  buildFrontmatter(lines: string[]): string {
+    return `---\n${lines.join("\n")}\n---`;
+  }
+
+  async createAndOpenNote(folder: string, title: string, body: string): Promise<void> {
+    const targetFolder = folder.trim() || this.settings.importFolder?.trim() || "_Second Brain/Inbox";
+    await this.ensureFolderExists(targetFolder);
+
+    const sanitizedTitle = this.sanitizeFileName(title);
+    const path = this.getAvailableFilePath(targetFolder, sanitizedTitle);
+
+    await this.app.vault.create(path, body);
+
+    const file = this.app.vault.getAbstractFileByPath(path);
+    if (file instanceof TFile) {
+      await this.app.workspace.getLeaf(true).openFile(file);
+    }
+
+    new Notice(`Saved note: ${sanitizedTitle}`);
+  }
+
+  defaultSearchNoteTitle(query: string): string {
+    const trimmed = query.trim();
+    if (!trimmed) return `Search - ${new Date().toISOString().slice(0, 10)}`;
+    return this.sanitizeFileName(trimmed);
+  }
+
+  defaultInsightNoteTitle(query: string): string {
+    const trimmed = query.trim();
+    if (!trimmed) return `Insight - ${new Date().toISOString().slice(0, 10)}`;
+    return this.sanitizeFileName(`Insight - ${trimmed}`);
+  }
+
+  formatResultDateLabel(createdAt: string | null): string | null {
+    if (!createdAt) return null;
+    const match = createdAt.match(/^\d{4}-\d{2}-\d{2}/);
+    return match ? match[0] : createdAt;
+  }
+
+  async saveSearchResultsAsNote(
+    query: string,
+    results: NormalizedRecallResult[],
+    title: string,
+    folder: string
+  ): Promise<void> {
+    const recalledAt = new Date().toISOString();
+    const escapedQuery = query.replace(/"/g, '\\"');
+
+    const frontmatter = this.buildFrontmatter([
+      `query: "${escapedQuery}"`,
+      `recalled_at: "${recalledAt}"`,
+      `source: second-brain`,
+    ]);
+
+    const entries = results.map((result) => {
+      const meta: string[] = [];
+      if (result.score !== null) meta.push(`score: ${result.score.toFixed(1)}`);
+      const dateLabel = this.formatResultDateLabel(result.createdAt);
+      if (dateLabel) meta.push(dateLabel);
+      const metaText = meta.length > 0 ? ` (${meta.join(" · ")})` : "";
+
+      const normalizedContent = this.normalizeMarkdown(result.content);
+      const indentedContent = normalizedContent
+        .split("\n")
+        .map((line) => (line.trim() === "" ? "" : `  ${line}`))
+        .join("\n");
+
+      const tagsLine = result.tags.length > 0
+        ? `\n  Tags: ${result.tags.map((t) => `#${t}`).join(" ")}`
+        : "";
+
+      return `- **${result.title}**${metaText}\n${indentedContent}${tagsLine}`;
+    });
+
+    const body = `${frontmatter}\n\n# ${title}\n\n${entries.join("\n\n")}\n`;
+    await this.createAndOpenNote(folder, title, body);
+  }
+
+  async saveSingleResultAsNote(
+    query: string,
+    result: NormalizedRecallResult,
+    title: string,
+    folder: string
+  ): Promise<void> {
+    const recalledAt = new Date().toISOString();
+    const escapedQuery = query.replace(/"/g, '\\"');
+
+    const frontmatter = this.buildFrontmatter([
+      `query: "${escapedQuery}"`,
+      `recalled_at: "${recalledAt}"`,
+      `source: second-brain`,
+    ]);
+
+    const normalizedContent = this.normalizeMarkdown(result.content);
+    const body = `${frontmatter}\n\n# ${title}\n\nSource memory ID: ${result.id}\n\n${normalizedContent}\n`;
+    await this.createAndOpenNote(folder, title, body);
+  }
+
+  async saveInsightAsNote(
+    query: string,
+    insight: string,
+    title: string,
+    folder: string
+  ): Promise<void> {
+    const recalledAt = new Date().toISOString();
+    const escapedQuery = query.replace(/"/g, '\\"');
+
+    const frontmatter = this.buildFrontmatter([
+      `query: "${escapedQuery}"`,
+      `recalled_at: "${recalledAt}"`,
+      `source: second-brain`,
+      `type: insight`,
+    ]);
+
+    const normalizedInsight = this.normalizeMarkdown(insight);
+    const body = `${frontmatter}\n\n# ${title}\n\n${normalizedInsight}\n`;
+    await this.createAndOpenNote(folder, title, body);
+  }
+
   async loadSettings() {
     this.settings = Object.assign({}, DEFAULT_SETTINGS, await this.loadData() as unknown as Partial<SecondBrainSettings>);
   }

--- a/main.ts
+++ b/main.ts
@@ -854,6 +854,7 @@ imported_at: "${importedAt}"${tagsYaml}
 
     const rawLines = content.split("\n");
     const output: string[] = [];
+    const outputInFence: boolean[] = []; // Track fence state for each output line
     let inFence = false;
 
     for (const rawLine of rawLines) {
@@ -864,15 +865,20 @@ imported_at: "${importedAt}"${tagsYaml}
       if (isFenceMarker) {
         if (!inFence) {
           const prev = output.length > 0 ? output[output.length - 1] : null;
-          if (prev !== null && prev.trim() !== "") output.push("");
+          if (prev !== null && prev.trim() !== "") {
+            output.push("");
+            outputInFence.push(false);
+          }
         }
         output.push(trimmedRight);
+        outputInFence.push(inFence); // Record state before toggle
         inFence = !inFence;
         continue;
       }
 
       if (inFence) {
         output.push(rawLine);
+        outputInFence.push(true);
         continue;
       }
 
@@ -888,9 +894,11 @@ imported_at: "${importedAt}"${tagsYaml}
 
       if (trimmed !== "" && prev !== null && prevTrimmed !== "" && lineIsStructural !== prevIsStructural) {
         output.push("");
+        outputInFence.push(false);
       }
 
       output.push(line);
+      outputInFence.push(false);
     }
 
     const collapsed: string[] = [];
@@ -900,7 +908,9 @@ imported_at: "${importedAt}"${tagsYaml}
         let j = i;
         while (j < output.length && output[j].trim() === "") j++;
         const runLength = j - i;
-        if (runLength >= 3) {
+        // Only collapse if NO lines in the run are inside a fence
+        const hasAnyInFence = outputInFence.slice(i, j).some((isFenced) => isFenced);
+        if (runLength >= 3 && !hasAnyInFence) {
           collapsed.push("");
         } else {
           for (let k = i; k < j; k++) collapsed.push(output[k]);

--- a/main.ts
+++ b/main.ts
@@ -1242,6 +1242,21 @@ class SearchView extends ItemView {
       });
     }
 
+    const saveResultButton = titleRow.createEl("button", {
+      cls: "second-brain-save-icon-button",
+      attr: { "aria-label": "Save memory as note" },
+    });
+    setIcon(saveResultButton, "file-plus");
+    saveResultButton.addEventListener("click", (evt) => {
+      evt.stopPropagation();
+      new SaveNoteModal(
+        this.app,
+        result.title,
+        this.defaultSaveFolder(),
+        (title, folder) => this.plugin.saveSingleResultAsNote(this.lastQuery, result, title, folder)
+      ).open();
+    });
+
     const bodyText = isExpanded ? result.content.replace(/\s+/g, " ").trim() : result.snippet;
     item.createEl("p", {
       text: bodyText,

--- a/main.ts
+++ b/main.ts
@@ -840,6 +840,81 @@ imported_at: "${importedAt}"${tagsYaml}
     return flat.slice(0, maxChars).trim() + "…";
   }
 
+  normalizeMarkdown(content: string): string {
+    const isStructural = (line: string): boolean => {
+      const trimmed = line.trim();
+      return (
+        /^#{1,6}\s/.test(trimmed) ||
+        /^[-*+]\s/.test(trimmed) ||
+        /^\d+[.)]\s/.test(trimmed) ||
+        /^>/.test(trimmed) ||
+        /^```/.test(trimmed)
+      );
+    };
+
+    const rawLines = content.split("\n");
+    const output: string[] = [];
+    let inFence = false;
+
+    for (const rawLine of rawLines) {
+      const trimmedRight = rawLine.replace(/[ \t]+$/, "");
+      const trimmed = trimmedRight.trim();
+      const isFenceMarker = /^```/.test(trimmed);
+
+      if (isFenceMarker) {
+        if (!inFence) {
+          const prev = output.length > 0 ? output[output.length - 1] : null;
+          if (prev !== null && prev.trim() !== "") output.push("");
+        }
+        output.push(trimmedRight);
+        inFence = !inFence;
+        continue;
+      }
+
+      if (inFence) {
+        output.push(rawLine);
+        continue;
+      }
+
+      let line = trimmedRight;
+      if (/^\s*[*+]\s/.test(line)) {
+        line = line.replace(/^(\s*)[*+](\s)/, "$1-$2");
+      }
+
+      const prev = output.length > 0 ? output[output.length - 1] : null;
+      const prevTrimmed = prev?.trim() ?? "";
+      const prevIsStructural = prev !== null && isStructural(prev);
+      const lineIsStructural = isStructural(line);
+
+      if (trimmed !== "" && prev !== null && prevTrimmed !== "" && lineIsStructural !== prevIsStructural) {
+        output.push("");
+      }
+
+      output.push(line);
+    }
+
+    const collapsed: string[] = [];
+    let i = 0;
+    while (i < output.length) {
+      if (output[i].trim() === "") {
+        let j = i;
+        while (j < output.length && output[j].trim() === "") j++;
+        const runLength = j - i;
+        if (runLength >= 3) {
+          collapsed.push("");
+        } else {
+          for (let k = i; k < j; k++) collapsed.push(output[k]);
+        }
+        i = j;
+      } else {
+        collapsed.push(output[i]);
+        i++;
+      }
+    }
+
+    return collapsed.join("\n").trim();
+  }
+
   async loadSettings() {
     this.settings = Object.assign({}, DEFAULT_SETTINGS, await this.loadData() as unknown as Partial<SecondBrainSettings>);
   }

--- a/main.ts
+++ b/main.ts
@@ -1064,6 +1064,7 @@ class SearchView extends ItemView {
   expandedIds: Set<string> = new Set();
   isSearching = false;
   requestToken = 0;
+  lastQuery = "";
 
   constructor(leaf: WorkspaceLeaf, plugin: SecondBrainPlugin) {
     super(leaf);
@@ -1123,6 +1124,7 @@ class SearchView extends ItemView {
     const query = this.queryInput.value;
     const token = ++this.requestToken;
     this.isSearching = true;
+    this.lastQuery = query;
     this.renderLoading();
 
     try {
@@ -1155,12 +1157,32 @@ class SearchView extends ItemView {
     });
   }
 
+  defaultSaveFolder(): string {
+    return this.plugin.settings.importFolder?.trim() || "_Second Brain/Inbox";
+  }
+
   renderResults(results: NormalizedRecallResult[], insight: string | null) {
     this.resultsEl.empty();
 
     if (insight) {
       const insightEl = this.resultsEl.createDiv({ cls: "second-brain-search-insight" });
-      insightEl.setText(insight);
+
+      const insightText = insightEl.createDiv({ cls: "second-brain-search-insight-text" });
+      insightText.setText(insight);
+
+      const saveInsightButton = insightEl.createEl("button", {
+        cls: "second-brain-save-icon-button",
+        attr: { "aria-label": "Save insight as note" },
+      });
+      setIcon(saveInsightButton, "file-plus");
+      saveInsightButton.addEventListener("click", () => {
+        new SaveNoteModal(
+          this.app,
+          this.plugin.defaultInsightNoteTitle(this.lastQuery),
+          this.defaultSaveFolder(),
+          (title, folder) => this.plugin.saveInsightAsNote(this.lastQuery, insight, title, folder)
+        ).open();
+      });
     }
 
     if (results.length === 0) {
@@ -1170,6 +1192,17 @@ class SearchView extends ItemView {
       });
       return;
     }
+
+    const saveAllRow = this.resultsEl.createDiv({ cls: "second-brain-search-save-all-row" });
+    const saveAllButton = saveAllRow.createEl("button", { text: "Save all as note" });
+    saveAllButton.addEventListener("click", () => {
+      new SaveNoteModal(
+        this.app,
+        this.plugin.defaultSearchNoteTitle(this.lastQuery),
+        this.defaultSaveFolder(),
+        (title, folder) => this.plugin.saveSearchResultsAsNote(this.lastQuery, results, title, folder)
+      ).open();
+    });
 
     const list = this.resultsEl.createEl("ul", { cls: "second-brain-search-list" });
 

--- a/styles.css
+++ b/styles.css
@@ -32,6 +32,10 @@
 }
 
 .second-brain-search-insight {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 8px;
   padding: 10px 14px;
   margin-bottom: 16px;
   border-radius: 6px;
@@ -110,4 +114,40 @@
   background: var(--background-secondary);
   border-radius: 999px;
   padding: 1px 8px;
+}
+
+.second-brain-search-insight-text {
+  flex: 1;
+}
+
+.second-brain-search-save-all-row {
+  display: flex;
+  justify-content: flex-end;
+  margin-bottom: 8px;
+}
+
+.second-brain-save-icon-button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+  padding: 2px;
+  background: transparent;
+  border: none;
+  box-shadow: none;
+  color: var(--text-muted);
+  cursor: pointer;
+}
+
+.second-brain-save-icon-button:hover {
+  color: var(--text-normal);
+  background: transparent;
+  box-shadow: none;
+}
+
+.second-brain-save-note-buttons {
+  display: flex;
+  justify-content: flex-end;
+  gap: 8px;
+  margin-top: 12px;
 }


### PR DESCRIPTION
Closes #3

## Summary
- Adds **Save all as note** button above the search results list to save the full result set as a combined Markdown note with frontmatter
- Adds a **per-result save icon** (`file-plus`) on each search result row to save a single memory as a note
- Adds a **save icon on the insight callout** to save the AI-generated insight as a note with `type: insight` frontmatter
- All three entry points open a `SaveNoteModal` to confirm/edit the note title and destination folder before saving
- Notes get YAML frontmatter: `query`, `recalled_at`, `source: second-brain` (insight notes also get `type: insight`)
- Memory content is cleaned up via a new `normalizeMarkdown()` helper (blank-line separation around structural blocks, bullet normalization, code-fence preservation)
- `NormalizedRecallResult` now carries `createdAt: string | null` for use in combined-note metadata

## Test Plan
- [ ] Run a search with results — "Save all as note" button appears above the list; submitting creates a note with correct frontmatter, a `# <title>` heading, and a Markdown bullet list of all results; note opens automatically
- [ ] Click the save icon on an individual result row — modal opens with that memory's title as default; submitting creates a note with `Source memory ID:` line and normalized full content; clicking the icon does NOT toggle row expand/collapse
- [ ] Run a search that returns an insight — save icon appears on the insight callout; submitting creates a note with `type: insight` in frontmatter and the insight text as body
- [ ] Edit the title and/or folder in the modal before saving — note is created at the overridden name/location
- [ ] Clear the title field and click Save — notice "Title cannot be empty." is shown, no note created
- [ ] Save to a folder that doesn't exist yet — folder is created automatically
- [ ] Save when a note with the same name already exists — new note gets a `(1)` suffix
- [ ] Search with no results — "Save all as note" button is absent; "No memories found" message shown
- [ ] Confirm existing search expand/collapse still works after this change